### PR TITLE
(Preview2) Profile File Uploads to StagingCheck for invalid sideprof tag (user changed name)

### DIFF
--- a/eros/components/Sidebar.tsx
+++ b/eros/components/Sidebar.tsx
@@ -201,6 +201,18 @@ const Sidebar = ({ hardEdge }: sidebarProps) => {
 		if (loading && !data) {
 			return loadingSidebar;
 		}
+		if (!data) {
+			//we cant check the findUserByTag if data does not exist, this causes site to
+			//flicker as it constantly reloads and crashes, user has most likely changed their
+			//tag in this situation, but the sideprof localstore contains old one
+			return (
+				<div className={hardEdge ? sidebarStyles.sidebar_full : sidebarStyles.sidebar}>
+					<p
+						className="fillfillcentercenter"
+						style={{ padding: "0 2em 0 2em", textAlign: "center" }}>{`User @${uTag} has not been found, they have most likely changed their account name`}</p>
+				</div>
+			);
+		}
 		if (!data.findUserByTag) {
 			//fix site crashing bc above condition passes when the data is still ull
 			//we have to wait a little bit more so that a user is returned


### PR DESCRIPTION
### 📜 Intent
This is the second test of the new ability to upload files to change your profile banner and profile picture. The first failed when a user changed their account name but the sidebar still tried to load their profile (from the old name stored in localstorage). This was not related to this new upload feature, but the still new editing of text data in one's profile feature which preceded editing images.

### ✅ Fixes
- Check for invalid sideprof tag in localstorage